### PR TITLE
Añadiendo un rust-toolchain.toml

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,3 @@
+[toolchain]
+channel = "nightly"
+profile = "default"


### PR DESCRIPTION
Añadí un rust-toolchain.toml para que se aplique la nightly por defecto en el sitio