### PR TITLE
fix: Improve slogan, delete max-w-lg

### DIFF
--- a/src/components/slogan_button.rs
+++ b/src/components/slogan_button.rs
@@ -42,7 +42,7 @@ pub fn SloganButton() -> impl IntoView {
 
     view! {
         <div
-            class="flex select-none items-center justify-center lg:justify-start group dark:text-white  max-w-lg drop-shadow-[7px_7px_2px_rgba(0,0,0,.5)] hover:drop-shadow-none dark:transition-all dark:ease-in-out  dark:delay-75 "
+            class="flex select-none items-center justify-center lg:justify-start group dark:text-white drop-shadow-[7px_7px_2px_rgba(0,0,0,.5)] hover:drop-shadow-none dark:transition-all dark:ease-in-out  dark:delay-75 "
             on:click=click_handler
         >
             <button class="bg-orange-200 dark:bg-black/30  border-4 border-orange-400 group-hover:border-orange-500 dark:group-hover:bg-black/60 flex justify-center items-center rounded-full w-12 h-12 text-xl relative z-10 drop-shadow-sm">


### PR DESCRIPTION
# Slogan component fixed on tablet view

![cambio2](https://github.com/RustLangES/RustLangES.github.io/assets/85712228/aa5ae252-e384-4725-88c5-6711986ae0b6)

