### PR TITLE
fix: fixed leptosfmt in nix flake

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -149,7 +149,7 @@
                 toolchain
                 trunk
                 cargo-leptos
-                cargo-leptosfmt
+                leptosfmt
                 cargo-make
                 binaryen
               ];


### PR DESCRIPTION
Se corrigió el paquete de `cargo.leptosfmt` a `leptosfmt`