### PR TITLE
Arreglar problema al momento de mostrar texto

### DIFF
--- a/src/components/cards/project_card.rs
+++ b/src/components/cards/project_card.rs
@@ -50,7 +50,7 @@ pub fn ProjectCard(
                 <div class="flex gap-4 sm:gap-0 justify-around items-center mt-4">
                     <ButtonLink href=button_link size="tiny">
                         {if button_text.is_empty() {
-                            name.join("")
+                            name.join(" ")
                         } else {
                             button_text.to_string()
                         }}


### PR DESCRIPTION
Esta pull request corrige un problema en la sección de proyectos dentro de la página de Rust Lang ES. En este caso, un texto se muestra correctamente mientras que el otro no.

![image](https://github.com/user-attachments/assets/6e36a67a-39de-4f14-bfd6-36a92a0431b1)
