### PR TITLE
Arreglar typo en el flake.nix

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -1,5 +1,5 @@
 {
-  description = "Rust Lang Esp flake for NixOs users";
+  description = "Rust Lang Es flake for NixOs users";
   inputs = {
     flake-parts.url = "github:hercules-ci/flake-parts";
     flake-utils.url = "github:numtide/flake-utils";


### PR DESCRIPTION
Esta pull request arregla un error tipográfico en la descripción del flake.nix. El error es que se escribe Rust Lang Esp en vez de Rust Lang Es.