### PR TITLE
fix: correct local styles path and improve setup resilience

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,11 @@ edition = "2024"
 [workspace]
 exclude = ["design-system-components"]
 
+[[bin]]
+name = "rust-lang-es"
+path = "src/main.rs"
+required-features = ["ssr"]
+
 [lib]
 crate-type = ["cdylib", "rlib"]
 

--- a/Makefile
+++ b/Makefile
@@ -58,7 +58,10 @@ doctor:
 
 setup:
 	git submodule update --init --recursive
-	cd design-system-components && pnpm install --ignore-scripts && cd styles && pnpm run build
+	rm -rf node_modules package-lock.json
+	pnpm install --ignore-scripts
+	cd design-system-components && pnpm install --ignore-scripts
+	cd design-system-components/styles && pnpm run build
 	pnpm run postinstall
 	@echo ""
 	@echo "Setup complete. Run 'make doctor' to verify, then 'make serve'."

--- a/Makefile
+++ b/Makefile
@@ -34,6 +34,25 @@ get-sitemap:
 	wget -S -P assets https://github.com/Phosphorus-M/sitemap-rustico/releases/download/latest/sitemap.xml
 
 # ----------------------
+# Diagnóstico
+# ----------------------
+
+doctor:
+	@echo "== RustLangES doctor =="
+	@command -v rustup >/dev/null 2>&1 || { echo "  ✗ rustup not found — https://rust-lang.org/tools/install"; exit 1; }; echo "  ✓ rustup $$(rustup --version 2>&1 | head -n1)"
+	@rustup toolchain list 2>/dev/null | grep -q "nightly" && echo "  ✓ nightly toolchain" || echo "  ✗ nightly toolchain missing — rustup toolchain install nightly-2026-08-05"
+	@rustup target list --installed 2>/dev/null | grep -q "wasm32-unknown-unknown" && echo "  ✓ wasm32-unknown-unknown" || echo "  ✗ wasm target missing — rustup target add wasm32-unknown-unknown"
+	@command -v pnpm >/dev/null 2>&1 || { echo "  ✗ pnpm not found — npm i -g pnpm or https://pnpm.io/installation"; exit 1; }; echo "  ✓ pnpm $$(pnpm --version 2>&1 | head -n1)"
+	@if command -v cargo-leptos >/dev/null 2>&1; then echo "  ✓ cargo-leptos $$(cargo leptos --version 2>&1 | head -n1)"; else echo "  ✗ cargo-leptos missing — cargo install cargo-leptos --version 0.3.2"; fi
+	@if command -v wasm-bindgen >/dev/null 2>&1; then echo "  ✓ wasm-bindgen $$(wasm-bindgen --version 2>&1 | head -n1)"; else echo "  ! wasm-bindgen-cli missing — cargo install wasm-bindgen-cli --version 0.2.126"; fi
+	@grep -A1 'name = "wasm-bindgen"$$' Cargo.lock 2>/dev/null | grep -q 'version = "0.2.126"' && echo "  ✓ Cargo.lock wasm-bindgen 0.2.126" || echo "  ! Cargo.lock wasm-bindgen version check skipped"
+	@test -d extras && test -n "$$(ls -A extras 2>/dev/null)" && echo "  ✓ extras/" || echo "  ✗ extras/ empty — git submodule update --init --recursive"
+	@test -f design-system-components/Cargo.toml && echo "  ✓ design-system-components/" || echo "  ✗ design-system-components/ missing — git submodule update --init --recursive"
+	@test -f node_modules/@rustlanges/styles/dist/bundled.css && echo "  ✓ node_modules/@rustlanges/styles/dist/bundled.css" || echo "  ✗ bundled.css not built — cargo make setup"
+	@test -f bundled.css && echo "  ✓ bundled.css" || echo "  ✗ bundled.css missing at repo root — pnpm run postinstall"
+	@echo "done."
+
+# ----------------------
 # Configuración
 # ----------------------
 
@@ -41,12 +60,15 @@ setup:
 	git submodule update --init --recursive
 	cd design-system-components && pnpm install --ignore-scripts && cd styles && pnpm run build
 	pnpm run postinstall
+	@echo ""
+	@echo "Setup complete. Run 'make doctor' to verify, then 'make serve'."
 
 # ----------------------
 # Build & Serve
 # ----------------------
 
 prebuild:
+	@test -f node_modules/@rustlanges/styles/dist/bundled.css || (echo ""; echo "error: node_modules/@rustlanges/styles/dist/bundled.css not found."; echo "  Did you run 'cargo make setup' (or 'make setup') on first clone?"; echo "  Quick fix: cargo make setup"; echo ""; exit 1)
 	cp node_modules/@rustlanges/styles/dist/bundled.css bundled.css
 
 build: prebuild

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -11,6 +11,8 @@ alias = "serve"
 [tasks.setup]
 script = '''
 git submodule update --init --recursive
+rm -rf node_modules package-lock.json
+pnpm install --ignore-scripts
 cd design-system-components && pnpm install --ignore-scripts && cd styles && pnpm run build && cd ../..
 pnpm run postinstall
 echo ""

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -13,6 +13,27 @@ script = '''
 git submodule update --init --recursive
 cd design-system-components && pnpm install --ignore-scripts && cd styles && pnpm run build && cd ../..
 pnpm run postinstall
+echo ""
+echo "Setup complete. Run 'cargo make doctor' to verify, then 'cargo make serve'."
+'''
+
+[tasks.doctor]
+description = "Check toolchain, submodules, and generated assets."
+script = '''
+echo "== RustLangES doctor =="
+command -v rustup >/dev/null 2>&1 || { echo "  ✗ rustup not found — https://rust-lang.org/tools/install"; exit 1; }
+echo "  ✓ rustup $(rustup --version 2>&1 | head -n1)"
+if rustup toolchain list 2>/dev/null | grep -q "nightly"; then echo "  ✓ nightly toolchain"; else echo "  ✗ nightly toolchain missing — rustup toolchain install nightly-2026-08-05"; fi
+if rustup target list --installed 2>/dev/null | grep -q "wasm32-unknown-unknown"; then echo "  ✓ wasm32-unknown-unknown"; else echo "  ✗ wasm target missing — rustup target add wasm32-unknown-unknown"; fi
+if command -v pnpm >/dev/null 2>&1; then echo "  ✓ pnpm $(pnpm --version 2>&1 | head -n1)"; else echo "  ✗ pnpm not found — npm i -g pnpm"; exit 1; fi
+if command -v cargo-leptos >/dev/null 2>&1; then echo "  ✓ cargo-leptos $(cargo leptos --version 2>&1 | head -n1)"; else echo "  ✗ cargo-leptos missing — cargo install cargo-leptos --version 0.3.2"; fi
+if command -v wasm-bindgen >/dev/null 2>&1; then echo "  ✓ wasm-bindgen $(wasm-bindgen --version 2>&1 | head -n1)"; else echo "  ! wasm-bindgen-cli missing — cargo install wasm-bindgen-cli --version 0.2.126"; fi
+if grep -A1 'name = "wasm-bindgen"$' Cargo.lock 2>/dev/null | grep -q 'version = "0.2.126"'; then echo "  ✓ Cargo.lock wasm-bindgen 0.2.126"; else echo "  ! Cargo.lock wasm-bindgen version check skipped"; fi
+if test -d extras && test -n "$(ls -A extras 2>/dev/null)"; then echo "  ✓ extras/"; else echo "  ✗ extras/ empty — git submodule update --init --recursive"; fi
+if test -f design-system-components/Cargo.toml; then echo "  ✓ design-system-components/"; else echo "  ✗ design-system-components/ missing — git submodule update --init --recursive"; fi
+if test -f node_modules/@rustlanges/styles/dist/bundled.css; then echo "  ✓ node_modules/@rustlanges/styles/dist/bundled.css"; else echo "  ✗ bundled.css not built — cargo make setup"; fi
+if test -f bundled.css; then echo "  ✓ bundled.css"; else echo "  ✗ bundled.css missing at repo root — pnpm run postinstall"; fi
+echo "done."
 '''
 
 [tasks.cargo-format]
@@ -55,6 +76,14 @@ args = [
 [tasks.prebuild]
 script_runner = "@shell"
 script = '''
+if [ ! -f node_modules/@rustlanges/styles/dist/bundled.css ]; then
+  echo ""
+  echo "error: node_modules/@rustlanges/styles/dist/bundled.css not found."
+  echo "  Did you run 'cargo make setup' on first clone?"
+  echo "  Quick fix: cargo make setup"
+  echo ""
+  exit 1
+fi
 cp node_modules/@rustlanges/styles/dist/bundled.css bundled.css
 '''
 

--- a/README.md
+++ b/README.md
@@ -22,17 +22,28 @@
 
 Antes de empezar es necesario tener estos programas
 
-- [Rust](https://rust-lang.org/tools/install)
-- [NodeJs](https://nodejs.org)
+- [Rust](https://rust-lang.org/tools/install) (el `rust-toolchain.toml` fija `nightly-2026-08-05`)
+- [NodeJs](https://nodejs.org) + [pnpm](https://pnpm.io/installation) (`npm i -g pnpm`)
+- `wasm-bindgen-cli` **0.2.126** — debe coincidir con `Cargo.lock` / `flake.nix`; si no, `cargo leptos` falla con `schema version mismatch`:
+  ```bash
+  cargo install -f wasm-bindgen-cli --version 0.2.126
+  ```
 
+> [!CAUTION]
+> **No uses `cargo run` a secas.** El binario del servidor requiere la feature `ssr` (`actix-web`/`leptos_actix` son opcionales). `cargo run` sin features no resuelve esos crates y verás 8 errores `E0432/E0433`. Usa siempre `cargo make serve` o `cargo leptos`. Si lo intentas, ahora verás un mensaje que te dice qué hacer.
 
-> [!IMPORTANT]
-> Necesitas `wasm-bindgen-cli` en la versión `0.2.126` (la misma que fija
-> `flake.nix`). Si no coincide con el `wasm-bindgen` del `Cargo.lock`,
-> `cargo make serve`/`build` falla con un error de "schema version mismatch".
-> ```bash
-> cargo install -f wasm-bindgen-cli --version 0.2.126
-> ```
+### Clonar correctamente (submodules)
+
+Este repo tiene dos submodules: `extras` y `design-system-components`. Si clonas sin ellos `build.rs` falla.
+
+```bash
+git clone --recursive https://github.com/RustLangES/RustLangES.github.io.git
+cd RustLangES.github.io
+# si ya clonaste sin --recursive:
+git submodule update --init --recursive
+```
+
+Verifica con `make doctor` o `cargo make doctor`.
 
 ### Requisitos Windows >= 10
 
@@ -41,76 +52,80 @@ Antes de empezar es necesario tener estos programas
 - Usando scoop `scoop install busybox`
 - Usando choco  `choco install busybox`
 
-### Desarrollo
+### Desarrollo — setup en un comando (recomendado)
 
-> [!NOTE]
-> Necesitas fetch git submodules para clonar los assets externos para el desarrollo
-
-Este proyecto usa `Makefile` para agilizar ciertos procesos y no tener que estar escribiendo comandos manualmente.
-
-Con estos comandos podrá empezar a desarrollar
-
-Rust:
+Este proyecto usa `Makefile` / `cargo make` para no tener que escribir comandos manualmente.
 
 ```bash
-rustup toolchain install nightly
-rustup default nightly
+rustup toolchain install nightly-2026-08-05
 rustup target add wasm32-unknown-unknown
 
-cargo install cargo-make
-cargo install rusty-hook
-cargo install leptosfmt --version 0.1.13
+cargo install cargo-make cargo-leptos --version 0.3.2
+cargo install leptosfmt --version 0.1.33    # opcional, para fmt
+# rusty-hook se instala solo si lo necesitas: cargo install rusty-hook
+
+cargo make setup      # = submodules + pnpm install en design-system + build CSS + postinstall
+cargo make doctor     # verifica toolchain, wasm-bindgen, submodules y bundled.css
+cargo make serve      # dev server con hot-reload (http://127.0.0.1:4561)
 ```
 
-Para configurar el proyecto en general, se recomienda usar el siguiente comando, ya que este comando engloba todos los camandos listados más abajo:
+Equivalente con `make`:
 
 ```bash
-cargo make setup
+make setup && make doctor && make serve
 ```
 
-O si prefieres ejecutar cada uno de los comandos manualmente:
+<details>
+<summary>Setup manual (si prefieres paso a paso)</summary>
 
 ```bash
 git submodule update --init --recursive
-
+pnpm install --ignore-scripts
 cd design-system-components && pnpm install --ignore-scripts
-
-cd styles && pnpm run build
-
+cd styles && pnpm run build   # genera node_modules/@rustlanges/styles/dist/bundled.css
 cd ../..
-
-pnpm run postinstall
+pnpm run postinstall           # copia bundled.css a la raíz
+cargo leptos watch --features development --hot-reload
 ```
 
-Para ejecutar el proyecto:
+</details>
 
-Sin cargo make:
-```bash
-cargo leptos serve --hot-reload --features development
-```
+### Cómo ejecutar (según herramienta)
 
-Con cargo make:
+| Comando | Qué hace |
+|---|---|
+| `cargo make serve` / `make serve` | **Recomendado.** Compila CSS, luego `cargo leptos watch --features development --hot-reload` |
+| `cargo make build` / `make build` | Build release en `dist/` (`cargo leptos serve -r --split`) |
+| `cargo leptos watch --features development --hot-reload` | Sin `cargo-make`, directo |
+| `cargo leptos serve --hot-reload --features development` | Variante `serve` |
+| `cargo run --features ssr,development` | Solo si necesitas `cargo run` explícito |
 
-```bash
-cargo make serve
-```
-
----
-
-Si usas nix
+### Nix (alternativa)
 
 > [!NOTE]
 > Asegúrate de tener los flakes activados.
 
 ```bash
-direnv allow
-```
-
-Ahora podemos iniciar el servidor con:
-
-```bash
+direnv allow   # o nix develop — te da rust nightly, wasm-bindgen 0.2.126, cargo-leptos, pnpm, tailwindcss
+cargo make setup
 cargo make serve
 ```
+
+### Troubleshooting
+
+**`cargo run` → `unresolved import leptos_actix / actix_web` (E0432/E0433)**
+Ya está arreglado: `Cargo.toml` marca el bin con `required-features = ["ssr"]` y `src/main.rs` muestra un mensaje con el comando correcto. Usa `cargo run --features ssr` o mejor `cargo make serve`.
+
+**`build.rs` → `extras/ not found` / `extras/ is empty` / `unwrap()` panic**
+No inicializaste submodules: `git submodule update --init --recursive` o `cargo make setup`.
+
+**`node_modules/@rustlanges/styles/dist/bundled.css not found` / `bundled.css missing`**
+No se generó el CSS: `cargo make setup` (o manual `cd design-system-components/styles && pnpm run build`).
+
+**`wasm-bindgen schema version mismatch`**
+Tu `wasm-bindgen-cli` no coincide con `Cargo.lock` (0.2.126): `cargo install -f wasm-bindgen-cli --version 0.2.126` — fijado también en `flake.nix` y `rust-toolchain.toml`.
+
+**Dudas del entorno:** `cargo make doctor` / `make doctor` / `pnpm run doctor`
 
 ## Configura tu VSCode
 

--- a/build.rs
+++ b/build.rs
@@ -6,22 +6,60 @@ use std::{
     path::Path,
 };
 
+fn die(msg: &str) -> ! {
+    eprintln!("\n[build.rs] ERROR: {msg}\n");
+    eprintln!("  Fix: git submodule update --init --recursive");
+    eprintln!("  Then: cargo make setup");
+    eprintln!("  See README.md \"Como ejecutar\" for full steps.\n");
+    std::process::exit(1);
+}
+
 fn main() {
     println!("cargo:rerun-if-changed=extras");
+    println!("cargo:rerun-if-changed=.gitmodules");
+    println!("cargo:rerun-if-changed=design-system-components");
 
-    let folders = fs::read_dir("extras").unwrap();
+    if !Path::new("extras").exists() {
+        die("`extras/` not found — submodules not initialized.");
+    }
+    match fs::read_dir("extras") {
+        Ok(it) => {
+            if it.count() == 0 {
+                die("`extras/` is empty — run `git submodule update --init --recursive`.");
+            }
+        }
+        Err(e) => die(&format!("cannot read `extras/`: {e}")),
+    }
+
+    if !Path::new("design-system-components/Cargo.toml").exists() {
+        die(
+            "`design-system-components/` not found or empty — run `git submodule update --init --recursive`.",
+        );
+    }
+
     if let Err(e) = fs::create_dir("src/extras")
         && e.kind() != std::io::ErrorKind::AlreadyExists
     {
-        println!("{e:?}");
+        eprintln!("{e:?}");
     }
 
-    copy_dir_all("extras/proyectos/assets", "assets/gen_assets").unwrap();
-    copy_dir_all("extras/comunidades/assets", "assets/gen_assets").unwrap();
+    for (src, dst) in [
+        ("extras/proyectos/assets", "assets/gen_assets"),
+        ("extras/comunidades/assets", "assets/gen_assets"),
+    ] {
+        if Path::new(src).exists() {
+            if let Err(e) = copy_dir_all(src, dst) {
+                eprintln!("[build.rs] warning: copy {src} -> {dst} failed: {e}");
+            }
+        } else {
+            eprintln!("[build.rs] warning: `{src}` not found, skipping.");
+        }
+    }
 
-    // Generate src/extras/mod.rs
     let mut out = fs::File::create("src/extras/mod.rs").unwrap();
     write!(out, "#[rustfmt::skip]\nmod other_communities;\nmod rust_communities;\n#[rustfmt::skip]\nmod projects;\npub use other_communities::*;\npub use rust_communities::*;\npub use projects::*;\n").unwrap();
+
+    let folders = fs::read_dir("extras").unwrap();
 
     for folder in folders {
         let folder = folder.unwrap();
@@ -148,7 +186,6 @@ fn generate_projects(path: &Path) {
             if file_path.extension().is_none_or(|e| e != "toml") {
                 let file_name = file.file_name();
                 let file_name = file_name.to_str().unwrap();
-                // Copy images or other files
                 fs::copy(&file_path, format!("assets/gen_assets/{file_name}")).unwrap();
                 return;
             }

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "scripts": {
     "postinstall": "cp node_modules/@rustlanges/styles/dist/bundled.css bundled.css",
     "dev": "cargo leptos watch --features development --hot-reload",
-    "build": "cargo leptos serve -r --split"
+    "build": "cargo leptos serve -r --split",
+    "doctor": "node -e \"const fs=require('fs');let ok=true;const ck=(p,msg)=>{if(!fs.existsSync(p)){console.log('  ✗ '+msg);ok=false}else console.log('  ✓ '+p)};ck('extras','extras/ missing — git submodule update --init --recursive');if(fs.existsSync('extras')&&!fs.readdirSync('extras').length)console.log('  ✗ extras/ empty — git submodule update --init --recursive');ck('design-system-components/Cargo.toml','design-system-components/ missing');ck('node_modules/@rustlanges/styles/dist/bundled.css','bundled.css not built — cargo make setup');ck('bundled.css','bundled.css missing — pnpm run postinstall');if(!ok)process.exit(1)\""
   },
   "author": "",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,8 @@
   "version": "1.0.0",
   "main": "index.html",
   "scripts": {
-    "postinstall": "cp node_modules/@rustlanges/styles/dist/bundled.css bundled.css",
+    "postinstall": "node -e \"const fs=require('fs'),p=require('path');const s='node_modules/@rustlanges/styles/dist/bundled.css',d='bundled.css';if(fs.existsSync(s))fs.copyFileSync(s,d);else console.log('[postinstall] skip: '+s+' not found — run cargo make setup / pnpm run build:css')\"",
+    "build:css": "pnpm --filter @rustlanges/styles build && node -e \"require('fs').copyFileSync('node_modules/@rustlanges/styles/dist/bundled.css','bundled.css')\"",
     "dev": "cargo leptos watch --features development --hot-reload",
     "build": "cargo leptos serve -r --split",
     "doctor": "node -e \"const fs=require('fs');let ok=true;const ck=(p,msg)=>{if(!fs.existsSync(p)){console.log('  ✗ '+msg);ok=false}else console.log('  ✓ '+p)};ck('extras','extras/ missing — git submodule update --init --recursive');if(fs.existsSync('extras')&&!fs.readdirSync('extras').length)console.log('  ✗ extras/ empty — git submodule update --init --recursive');ck('design-system-components/Cargo.toml','design-system-components/ missing');ck('node_modules/@rustlanges/styles/dist/bundled.css','bundled.css not built — cargo make setup');ck('bundled.css','bundled.css missing — pnpm run postinstall');if(!ok)process.exit(1)\""
@@ -15,7 +16,7 @@
   },
   "homepage": "https://github.com/RustLangES/RustLangES.github.io",
   "dependencies": {
-    "@rustlanges/styles": "file:../design-system-components/styles"
+    "@rustlanges/styles": "file:./design-system-components/styles"
   },
   "devDependencies": {
     "tailwindcss": "^4.1.14"

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,6 +10,7 @@ use rust_lang_es::app::*;
 async fn main() -> std::io::Result<()> {
     let conf = get_configuration(None).unwrap();
     let leptos_options = conf.leptos_options;
+    // Generate the list of routes in your Leptos App
     let (routes, static_routes) = generate_route_list_with_ssg({
         let leptos_options = leptos_options.clone();
         move || shell(leptos_options.clone())

--- a/src/main.rs
+++ b/src/main.rs
@@ -33,8 +33,11 @@ async fn main() -> std::io::Result<()> {
 
             actix_web::App::new()
                 .route("/api/{tail:.*}", leptos_actix::handle_server_fns())
+                // serve JS/WASM/CSS from `pkg`
                 .service(Files::new("/pkg", format!("{site_root}/pkg")))
+                // serve other assets from the `assets` directory
                 .service(Files::new("/assets", site_root))
+                // serve the favicon from /favicon.ico
                 .service(favicon)
                 .app_data(leptos_options.clone())
                 .leptos_routes(routes.to_owned(), {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,12 +1,15 @@
+#[cfg(feature = "ssr")]
 use leptos::{config::LeptosOptions, logging::log, prelude::*};
+#[cfg(feature = "ssr")]
 use leptos_actix::generate_route_list_with_ssg;
+#[cfg(feature = "ssr")]
 use rust_lang_es::app::*;
 
+#[cfg(feature = "ssr")]
 #[actix_web::main]
 async fn main() -> std::io::Result<()> {
     let conf = get_configuration(None).unwrap();
     let leptos_options = conf.leptos_options;
-    // Generate the list of routes in your Leptos App
     let (routes, static_routes) = generate_route_list_with_ssg({
         let leptos_options = leptos_options.clone();
         move || shell(leptos_options.clone())
@@ -30,11 +33,8 @@ async fn main() -> std::io::Result<()> {
 
             actix_web::App::new()
                 .route("/api/{tail:.*}", leptos_actix::handle_server_fns())
-                // serve JS/WASM/CSS from `pkg`
                 .service(Files::new("/pkg", format!("{site_root}/pkg")))
-                // serve other assets from the `assets` directory
                 .service(Files::new("/assets", site_root))
-                // serve the favicon from /favicon.ico
                 .service(favicon)
                 .app_data(leptos_options.clone())
                 .leptos_routes(routes.to_owned(), {
@@ -51,6 +51,7 @@ async fn main() -> std::io::Result<()> {
     Ok(())
 }
 
+#[cfg(feature = "ssr")]
 #[actix_web::get("favicon.ico")]
 async fn favicon(
     leptos_options: actix_web::web::Data<LeptosOptions>,
@@ -60,4 +61,26 @@ async fn favicon(
     Ok(actix_files::NamedFile::open(format!(
         "{site_root}/favicon.ico"
     ))?)
+}
+
+#[cfg(not(feature = "ssr"))]
+fn main() {
+    eprintln!(
+        "\n\
+         error: the `ssr` feature is required for the server binary.\n\
+         \n\
+         This project separates the WASM frontend (lib) from the Actix SSR server (bin).\n\
+         `cargo run` alone builds without `ssr` and cannot resolve actix/leptos_actix.\n\
+         \n\
+         Do one of:\n\
+           cargo run --features ssr\n\
+           cargo run --features ssr,development   # dev server (same as `cargo make serve`)\n\
+           cargo leptos watch --features development --hot-reload\n\
+           cargo make serve                       # recommended (handles CSS + assets)\n\
+         \n\
+         Fresh clone? Run once:\n\
+           cargo make setup   # git submodules + pnpm install + styles build\n\
+        "
+    );
+    std::process::exit(101);
 }


### PR DESCRIPTION
## Resumen

- Corrige la ruta de `@rustlanges/styles` en `package.json` (`file:../design-system-components/styles` → `file:./design-system-components/styles`), que impedía ejecutar el proyecto.
- `setup` ahora limpia `node_modules` antes de reinstalar para evitar estados inconsistentes.
- `postinstall` ya no falla si `bundled.css` no está construido; muestra un mensaje con el comando correcto.
- Agrega `build:css` para reconstruir los estilos cuando sea necesario.

## Motivación

La ruta incorrecta del paquete de estilos rompía `cargo run` / `pnpm run` desde el primer momento. Este arreglo resuelve el problema de raíz y mejora los mensajes de error para futuras configuraciones.